### PR TITLE
修复服务器启动崩溃

### DIFF
--- a/src/main/java/ink/ikx/rt/Main.java
+++ b/src/main/java/ink/ikx/rt/Main.java
@@ -12,6 +12,7 @@ import ink.ikx.rt.api.mods.jei.core.IJeiPanel;
 import ink.ikx.rt.api.mods.jei.core.IJeiRecipe;
 import ink.ikx.rt.impl.internal.config.RTConfig;
 import ink.ikx.rt.impl.internal.proxy.IProxy;
+import ink.ikx.rt.impl.internal.proxy.ServerProxy;
 import ink.ikx.rt.impl.mods.botania.module.SubTileOrechidManager;
 import ink.ikx.rt.impl.mods.botania.subtile.SubTileHydroangeasModified;
 import ink.ikx.rt.impl.mods.botania.subtile.SubTileOrechidModified;
@@ -54,11 +55,14 @@ public class Main {
     public static final Set<IJeiRecipe> JEI_RECIPE_SET = Sets.newHashSet();
     public static final BiMap<String, Pair<String, ISubTileEntityRepresentation>> SUB_TILE_GENERATING_MAP = HashBiMap.create();
 
-    @SidedProxy(clientSide = "ink.ikx.rt.impl.internal.proxy.ClientProxy", serverSide = "ink.ikx.rt.impl.internal.proxy.SeverProxy")
+    public static boolean isOnServer = false;
+
+    @SidedProxy(clientSide = "ink.ikx.rt.impl.internal.proxy.ClientProxy", serverSide = "ink.ikx.rt.impl.internal.proxy.ServerProxy")
     public static IProxy proxy;
 
     @EventHandler
     public void onConstruct(FMLConstructionEvent event) {
+        isOnServer = (proxy instanceof ServerProxy);
         CraftTweakerExtension.registerAllClass();
         MinecraftForge.EVENT_BUS.register(CTEventManager.Handler.class);
         if (Loader.isModLoaded("botania")) {

--- a/src/main/java/ink/ikx/rt/api/mods/jei/elements/IJeiElement.java
+++ b/src/main/java/ink/ikx/rt/api/mods/jei/elements/IJeiElement.java
@@ -46,7 +46,4 @@ public abstract class IJeiElement {
     }
 
 
-    @SideOnly(Side.CLIENT)
-    public abstract void render(Minecraft minecraft);
-
 }

--- a/src/main/java/ink/ikx/rt/api/mods/jei/slots/IJeiSlot.java
+++ b/src/main/java/ink/ikx/rt/api/mods/jei/slots/IJeiSlot.java
@@ -1,7 +1,6 @@
 package ink.ikx.rt.api.mods.jei.slots;
 
 import crafttweaker.annotations.ModOnly;
-import net.minecraft.client.Minecraft;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenProperty;
 
@@ -27,6 +26,4 @@ public abstract class IJeiSlot {
         this.isInput = isInput;
         this.hasBase = hasBase;
     }
-
-    public abstract void render(Minecraft minecraft);
 }

--- a/src/main/java/ink/ikx/rt/api/mods/jei/slots/IJeiSlotRenderable.java
+++ b/src/main/java/ink/ikx/rt/api/mods/jei/slots/IJeiSlotRenderable.java
@@ -1,0 +1,10 @@
+package ink.ikx.rt.api.mods.jei.slots;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public interface IJeiSlotRenderable {
+    @SideOnly(Side.CLIENT)
+    public abstract void render(Minecraft minecraft);
+}

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/impl/MCJeiSlots.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/impl/MCJeiSlots.java
@@ -3,11 +3,12 @@ package ink.ikx.rt.impl.mods.jei.impl;
 import ink.ikx.rt.api.mods.jei.IJeiUtils;
 import ink.ikx.rt.api.mods.jei.slots.IJeiSlotItem;
 import ink.ikx.rt.api.mods.jei.slots.IJeiSlotLiquid;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import net.minecraft.client.Minecraft;
 
 public class MCJeiSlots {
 
-    public static class MCJeiSlotItem extends IJeiSlotItem {
+    public static class MCJeiSlotItem extends IJeiSlotItem implements IJeiSlotRenderable {
 
         public MCJeiSlotItem(int x, int y, boolean isInput, boolean hasBase) {
             super(x, y, isInput, hasBase);
@@ -17,15 +18,23 @@ public class MCJeiSlots {
         public void render(Minecraft minecraft) {
             if (!hasBase) return;
             if (isInput) {
-                IJeiUtils.createItemInputElement(x, y).render(minecraft);
+                try {
+                    ((IJeiSlotRenderable) IJeiUtils.createItemInputElement(x, y)).render(minecraft);
+                }catch (ClassCastException e){
+                    //
+                }
             } else {
-                IJeiUtils.createItemOutputElement(x, y).render(minecraft);
+                try {
+                    ((IJeiSlotRenderable) IJeiUtils.createItemOutputElement(x, y)).render(minecraft);
+                }catch (ClassCastException e){
+                    //
+                }
             }
         }
 
     }
 
-    public static class MCJeiSlotLiquid extends IJeiSlotLiquid {
+    public static class MCJeiSlotLiquid extends IJeiSlotLiquid implements IJeiSlotRenderable{
 
         public MCJeiSlotLiquid(int x, int y, int width, int height, int capacityMb,
                                boolean showCapacity, boolean isInput, boolean hasBase) {
@@ -35,7 +44,11 @@ public class MCJeiSlots {
         @Override
         public void render(Minecraft minecraft) {
             if (!hasBase) return;
-            IJeiUtils.createLiquidElement(x, y, width, height).render(minecraft);
+            try {
+                ((IJeiSlotRenderable) IJeiUtils.createLiquidElement(x, y, width, height)).render(minecraft);
+            }catch (ClassCastException e){
+                //
+            }
         }
 
     }

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElementArrow.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElementArrow.java
@@ -2,12 +2,13 @@ package ink.ikx.rt.impl.mods.jei.impl.elemenet;
 
 import crafttweaker.CraftTweakerAPI;
 import ink.ikx.rt.api.mods.jei.elements.IJeiElements;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import ink.ikx.rt.impl.mods.jei.JeiPlugin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.util.ResourceLocation;
 
-public class MCJeiElementArrow extends IJeiElements.IJeiElementArrow {
+public class MCJeiElementArrow extends IJeiElements.IJeiElementArrow implements IJeiSlotRenderable {
 
     public MCJeiElementArrow(int x, int y, int direction) {
         super(x, y, direction);

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElementLiquid.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElementLiquid.java
@@ -1,12 +1,13 @@
 package ink.ikx.rt.impl.mods.jei.impl.elemenet;
 
 import ink.ikx.rt.api.mods.jei.elements.IJeiElements;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import ink.ikx.rt.impl.mods.jei.JeiPlugin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.util.ResourceLocation;
 
-public class MCJeiElementLiquid extends IJeiElements.IJeiElementLiquid {
+public class MCJeiElementLiquid extends IJeiElements.IJeiElementLiquid implements IJeiSlotRenderable {
 
     public MCJeiElementLiquid(int x, int y, int width, int height) {
         super(x, y, width, height);

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElementManaBar.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElementManaBar.java
@@ -1,11 +1,12 @@
 package ink.ikx.rt.impl.mods.jei.impl.elemenet;
 
 import ink.ikx.rt.api.mods.jei.elements.IJeiElements;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import net.minecraft.client.Minecraft;
 import vazkii.botania.client.core.handler.HUDHandler;
 import vazkii.botania.common.block.tile.mana.TilePool;
 
-public class MCJeiElementManaBar extends IJeiElements.IJeiElementManaBar {
+public class MCJeiElementManaBar extends IJeiElements.IJeiElementManaBar implements IJeiSlotRenderable {
 
     public int multiplesLog = 0;
     public int manaMax = TilePool.MAX_MANA_DILLUTED;

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElements.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/impl/elemenet/MCJeiElements.java
@@ -1,6 +1,7 @@
 package ink.ikx.rt.impl.mods.jei.impl.elemenet;
 
 import ink.ikx.rt.api.mods.jei.elements.IJeiElements;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import ink.ikx.rt.impl.mods.jei.JeiPlugin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -9,7 +10,7 @@ import net.minecraft.util.ResourceLocation;
 
 public class MCJeiElements {
 
-    public static class MCJeiElementItemInput extends IJeiElements.IJeiElementItemInput {
+    public static class MCJeiElementItemInput extends IJeiElements.IJeiElementItemInput implements IJeiSlotRenderable {
 
         public MCJeiElementItemInput(int x, int y) {
             super(x, y);
@@ -23,7 +24,7 @@ public class MCJeiElements {
 
     }
 
-    public static class MCJeiElementItemOutput extends IJeiElements.IJeiElementItemOutput {
+    public static class MCJeiElementItemOutput extends IJeiElements.IJeiElementItemOutput implements IJeiSlotRenderable{
 
         public MCJeiElementItemOutput(int x, int y) {
             super(x, y);
@@ -37,7 +38,7 @@ public class MCJeiElements {
 
     }
 
-    public static class MCJeiElementFontInfo extends IJeiElements.IJeiElementFontInfo {
+    public static class MCJeiElementFontInfo extends IJeiElements.IJeiElementFontInfo implements IJeiSlotRenderable{
 
         public MCJeiElementFontInfo(int x, int y, int width, int height, int color, String info) {
             super(x, y, width, height, color, info);
@@ -51,7 +52,7 @@ public class MCJeiElements {
 
     }
 
-    public static class MCJeiElementImage extends IJeiElements.IJeiElementImage {
+    public static class MCJeiElementImage extends IJeiElements.IJeiElementImage implements IJeiSlotRenderable{
 
 
         public MCJeiElementImage(int u, int v, int x, int y, int width, int height,

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/recipe/DynamicRecipesCategory.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/recipe/DynamicRecipesCategory.java
@@ -2,9 +2,12 @@ package ink.ikx.rt.impl.mods.jei.recipe;
 
 import cn.hutool.core.util.StrUtil;
 import crafttweaker.api.minecraft.CraftTweakerMC;
+import ink.ikx.rt.Main;
+import ink.ikx.rt.api.mods.jei.elements.IJeiElement;
 import ink.ikx.rt.api.mods.jei.slots.IJeiSlot;
 import ink.ikx.rt.api.mods.jei.slots.IJeiSlotItem;
 import ink.ikx.rt.api.mods.jei.slots.IJeiSlotLiquid;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import ink.ikx.rt.impl.mods.jei.impl.core.MCJeiPanel;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -73,12 +76,38 @@ public class DynamicRecipesCategory implements IRecipeCategory<DynamicRecipesWra
         return this.icon;
     }
 
+    public static void draw(IJeiSlot slot, Minecraft minecraft){
+
+    }
+
+
+    public static final int JEI_ELEMENT_ARROW = 0;
+    public static final int JEI_FONT_INFO = 1;
+    public static final int JEI_ITEM_INPUT = 2;
+    public static final int JEI_ITEM_OUTPUT = 3;
+    public static final int JEI_ELEMENT_IMAGE = 4;
+    public static final int JEI_ITEM_LIQUID = 5;
+    public static final int JEI_ITEM_MANABAR = 6;
+
+
+    public static void draw(IJeiElement element, Minecraft minecraft){
+
+
+    }
+
     @Override
     public void drawExtras(Minecraft minecraft) {
-        GlStateManager.enableAlpha();
-        panel.slots.forEach(s -> s.render(minecraft));
-        panel.elements.forEach(e -> e.render(minecraft));
-        GlStateManager.disableAlpha();
+        if(!Main.isOnServer) {
+            GlStateManager.enableAlpha();
+            try {
+                panel.slots.forEach(s -> ((IJeiSlotRenderable) s).render(minecraft));
+                panel.elements.forEach(e -> ((IJeiSlotRenderable) e).render(minecraft));
+            } catch (Exception e) {
+                System.out.println("Caught exception rendering a slot.");
+                e.printStackTrace();
+            }
+            GlStateManager.disableAlpha();
+        }
     }
 
     @Nonnull

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/recipe/DynamicRecipesWrapper.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/recipe/DynamicRecipesWrapper.java
@@ -1,6 +1,8 @@
 package ink.ikx.rt.impl.mods.jei.recipe;
 
 import crafttweaker.api.item.IIngredient;
+import ink.ikx.rt.Main;
+import ink.ikx.rt.api.mods.jei.slots.IJeiSlotRenderable;
 import ink.ikx.rt.impl.internal.utils.InternalUtils;
 import ink.ikx.rt.impl.mods.jei.impl.core.MCJeiRecipe;
 import mezz.jei.api.ingredients.IIngredients;
@@ -50,9 +52,16 @@ public class DynamicRecipesWrapper implements IRecipeWrapper {
 
     @Override
     public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
-        GlStateManager.enableAlpha();
-        recipe.elements.forEach(e -> e.render(minecraft));
-        GlStateManager.disableAlpha();
+        if(!Main.isOnServer) {
+            GlStateManager.enableAlpha();
+            try {
+                recipe.elements.forEach(e -> ((IJeiSlotRenderable) e).render(minecraft));
+            } catch (Exception e) {
+                System.out.println("Caught exception rendering a slot.");
+                e.printStackTrace();
+            }
+            GlStateManager.disableAlpha();
+        }
     }
 
     @Nonnull


### PR DESCRIPTION
- 修复了SidedProxy中错误的拼写 "Sever"
- 添加了接口IJeiSlotRenderable提供render方法，这样在服务端注册CrT类时不会因`import net.minecraft.client.Minecraft`导致报错崩溃